### PR TITLE
Update references to JSONField to support dj >= 4.0

### DIFF
--- a/pgq/migrations/0001_initial.py
+++ b/pgq/migrations/0001_initial.py
@@ -5,6 +5,12 @@ import django.contrib.postgres.functions
 from django.db import migrations, models
 
 
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField  # type: ignore[misc]
+
+
 class Migration(migrations.Migration):
 
     initial = True
@@ -36,7 +42,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("task", models.CharField(max_length=255)),
-                ("args", django.contrib.postgres.fields.jsonb.JSONField()),
+                ("args", JSONField()),
                 (
                     "queue",
                     models.CharField(

--- a/pgq/models.py
+++ b/pgq/models.py
@@ -3,7 +3,11 @@ from typing import Any, Dict, Iterable, Optional, Sequence, Type, TypeVar
 from django.db import models
 from django.db import connection
 from django.contrib.postgres.functions import TransactionNow
-from django.contrib.postgres.fields import JSONField
+
+try:
+    from django.db.models import JSONField
+except ImportError:
+    from django.contrib.postgres.fields import JSONField  # type: ignore[misc]
 
 DEFAULT_QUEUE_NAME = "default"
 


### PR DESCRIPTION
Keeps backwards compatiblity for django < 3.1