### PR TITLE
Fix worker crash when transaction.on_commit() callback fails

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,21 @@ Comparison to Celery
 django-pg-queue fills the same role as Celery. You must use postgres as the backend
 and the library is small enough that you can read and understand all the code.
 
+
+A note on the use of ``AtLeastOnceQueue`` and Django's ``transaction.on_commit()``
+----------------------------------------------------------------------------------
+
+A failure in an ``on_commit()`` callback will not cause that job to be retried
+when using an ``AtLeastOnceQueue`` (usually a job in an ``AtLeastOnceQueue``
+queue will remain in the queue if the job fails).  This is because
+``on_commit()`` callbacks are executed after the transaction has been committed
+and, for django-pg-queue, the job is removed from the queue when the transaction
+commits.
+
+If you require more certainty that the code in an ``on_commit()`` callback is
+executed successfully, you may need to ensure it is idempotent and call it from
+within the job rather than using ``on_commit()``.
+
 Usage
 =====
 

--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -1,4 +1,5 @@
 import abc
+import contextlib
 import datetime
 import logging
 import select
@@ -30,6 +31,15 @@ if TYPE_CHECKING:
     _Self = TypeVar("_Self", bound="BaseQueue"[Any])
 else:
     _Self = None
+
+
+@contextlib.contextmanager
+def maybe_atomic(is_atomic, **atomic_kwargs):
+    if is_atomic:
+        with transaction.atomic(**atomic_kwargs) as ctx:
+            yield ctx
+    else:
+        yield None
 
 
 class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
@@ -152,7 +162,7 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
             cur.execute('NOTIFY "%s";' % self.notify_channel)
 
     def _run_once(
-        self: _Self, exclude_ids: Optional[Iterable[int]] = None
+        self: _Self, exclude_ids: Optional[Iterable[int]] = None, is_atomic: bool = True
     ) -> Optional[Tuple[_Job, Any]]:
         """Get a job from the queue and run it.
 
@@ -166,20 +176,21 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
         If a job fails, ``PgqException`` is raised with the job object that
         failed stored in it.
         """
-        job = self.job_model.dequeue(
-            exclude_ids=exclude_ids, queue=self.queue, tasks=list(self.tasks)
-        )
-        if job:
-            self.logger.debug(
-                "Claimed %r.", job, extra={"data": {"job": job.to_json(),}}
-            )
-            try:
-                return job, self.run_job(job)
-            except Exception as e:
-                # Add job info to exception to be accessible for logging.
-                raise PgqException(job=job) from e
-        else:
-            return None
+        try:
+            with maybe_atomic(is_atomic):
+                job = self.job_model.dequeue(
+                    exclude_ids=exclude_ids, queue=self.queue, tasks=list(self.tasks)
+                )
+                if job:
+                    self.logger.debug(
+                        "Claimed %r.", job, extra={"data": {"job": job.to_json(),}}
+                    )
+                    return job, self.run_job(job)
+                else:
+                    return None
+        except Exception as e:
+            # Add job info to exception to be accessible for logging.
+            raise PgqException(job=job) from e
 
 
 class Queue(BaseQueue[Job]):
@@ -191,12 +202,11 @@ class AtMostOnceQueue(Queue):
         self, exclude_ids: Optional[Iterable[int]] = None
     ) -> Optional[Tuple[Job, Any]]:
         assert not connection.in_atomic_block
-        return self._run_once(exclude_ids=exclude_ids)
+        return self._run_once(exclude_ids=exclude_ids, is_atomic=False)
 
 
 class AtLeastOnceQueue(Queue):
-    @transaction.atomic
     def run_once(
         self, exclude_ids: Optional[Iterable[int]] = None
     ) -> Optional[Tuple[Job, Any]]:
-        return self._run_once(exclude_ids=exclude_ids)
+        return self._run_once(exclude_ids=exclude_ids, is_atomic=True)

--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -34,9 +34,9 @@ else:
 
 
 @contextlib.contextmanager
-def maybe_atomic(is_atomic, **atomic_kwargs):
+def maybe_atomic(is_atomic: bool) -> Optional[transaction.Atomic]:
     if is_atomic:
-        with transaction.atomic(**atomic_kwargs) as ctx:
+        with transaction.atomic() as ctx:
             yield ctx
     else:
         yield None


### PR DESCRIPTION
The exception was raised when exiting the @transaction.atomic, which was
outside of our exception handler. This meant the worker crashed and
stopped processing tasks.

Downstreamed from django-postgres-queue. Thanks @gavinwahl!