### PR TITLE
BaseQueue#_run_once: always have a job variable

### DIFF
--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -176,6 +176,7 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
         If a job fails, ``PgqException`` is raised with the job object that
         failed stored in it.
         """
+        job = None
         try:
             with maybe_atomic(is_atomic):
                 job = self.job_model.dequeue(


### PR DESCRIPTION
always have a job variable so that if there is an exception when fetching the job we get the correct type of exception


```
OperationalError: terminating connection due to administrator command
SSL connection has been closed unexpectedly
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)

OperationalError: terminating connection due to administrator command
SSL connection has been closed unexpectedly
server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

  File "pgq/queue.py", line 40, in maybe_atomic
    yield
  File "pgq/queue.py", line 181, in _run_once
    job = self.job_model.dequeue(
  File "pgq/models.py", line 71, in dequeue
    jobs = list(
  File "django/db/models/query.py", line 1484, in __iter__
    self._fetch_all()
  File "django/db/models/query.py", line 1471, in _fetch_all
    self._result_cache = list(self.iterator())
  File "django/db/models/query.py", line 1494, in iterator
    query = iter(self.query)
  File "django/db/models/sql/query.py", line 101, in __iter__
    self._execute_query()
  File "django/db/models/sql/query.py", line 141, in _execute_query
    self.cursor.execute(self.sql, params)
  File "django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "django/db/backends/utils.py", line 79, in _execute
    with self.db.wrap_database_errors:
  File "django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)

OperationalError: connection to server at "192.168.69.1", port 5432 failed: server closed the connection unexpectedly
	This probably means the server terminated abnormally
	before or while processing the request.

  File "django/db/backends/base/base.py", line 219, in ensure_connection
    self.connect()
  File "django/utils/asyncio.py", line 33, in inner
    return func(*args, **kwargs)
  File "django/db/backends/base/base.py", line 200, in connect
    self.connection = self.get_new_connection(conn_params)
  File "django/utils/asyncio.py", line 33, in inner
    return func(*args, **kwargs)
  File "django/db/backends/postgresql/base.py", line 187, in get_new_connection
    connection = Database.connect(**conn_params)
  File "__init__.py", line 122, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)

```