### PR TITLE
feat: Modernize testing infrastructure for current Python/Django versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        django-version: ["django42", "django52"]
 
     # Service containers to run with `container-job`
     services:
@@ -34,17 +35,17 @@ jobs:
           - 5432:5432
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: psycopg2 prerequisites
         run: sudo apt-get install libpq-dev
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip tox tox-factor
-      - name: Run tox targets for ${{ matrix.python-version }}
+          python -m pip install --upgrade pip tox
+      - name: Run tox targets for ${{ matrix.python-version }} with ${{ matrix.django-version }}
         run: |
           PYVERSION=$(python -c "import sys; print(''.join([str(sys.version_info.major), str(sys.version_info.minor)]))")
-          python -m tox -f "py${PYVERSION}"
+          python -m tox -e "py${PYVERSION}-${{ matrix.django-version }}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: check-docstring-first
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.8
+    hooks:
+      - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/manage.py
+++ b/manage.py
@@ -10,9 +10,9 @@ if __name__ == "__main__":
         # The above import may fail for some other reason. Ensure that the
         # issue is really that Django is missing to avoid masking other
         # exceptions on Python 2.
-        try:
-            import django
-        except ImportError:
+        import importlib.util
+
+        if importlib.util.find_spec("django") is None:
             raise ImportError(
                 "Couldn't import Django. Are you sure it's installed and "
                 "available on your PYTHONPATH environment variable? Did you "

--- a/pgq/migrations/0001_initial.py
+++ b/pgq/migrations/0001_initial.py
@@ -12,7 +12,6 @@ except ImportError:
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []  # type: ignore

--- a/pgq/queue.py
+++ b/pgq/queue.py
@@ -82,7 +82,12 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
             job,
             time.time() - start_time,
             retval,
-            extra={"data": {"job": job.to_json(), "retval": retval,}},
+            extra={
+                "data": {
+                    "job": job.to_json(),
+                    "retval": retval,
+                }
+            },
         )
         return retval
 
@@ -114,7 +119,6 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
         kwargs_list: Sequence[Dict[str, Any]],
         batch_size: Optional[int] = None,
     ) -> List[_Job]:
-
         assert task in self.tasks
 
         jobs = self.job_model.objects.bulk_create(
@@ -183,7 +187,13 @@ class BaseQueue(Generic[_Job], metaclass=abc.ABCMeta):
                 )
                 if job:
                     self.logger.debug(
-                        "Claimed %r.", job, extra={"data": {"job": job.to_json(),}}
+                        "Claimed %r.",
+                        job,
+                        extra={
+                            "data": {
+                                "job": job.to_json(),
+                            }
+                        },
                     )
                     return job, self.run_job(job)
                 else:

--- a/testproj/models.py
+++ b/testproj/models.py
@@ -1,5 +1,3 @@
-from django.db import models
-
 from pgq.models import BaseJob
 
 

--- a/testproj/settings.py
+++ b/testproj/settings.py
@@ -104,9 +104,15 @@ AUTH_PASSWORD_VALIDATORS = [
     {
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",  # noqa
     },
-    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",},
-    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",},
-    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",},
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
+    },
 ]
 
 
@@ -142,7 +148,14 @@ LOGGING = {
         "verbose": {
             "format": "%(levelname)s %(asctime)s %(name)s %(process)d: %(message)s",
         },
-        "simple": {"format": "%(levelname)s %(message)s",},
+        "simple": {
+            "format": "%(levelname)s %(message)s",
+        },
     },
-    "loggers": {"pgq": {"handlers": ["console"], "level": "DEBUG",},},
+    "loggers": {
+        "pgq": {
+            "handlers": ["console"],
+            "level": "DEBUG",
+        },
+    },
 }

--- a/testproj/test_decorators.py
+++ b/testproj/test_decorators.py
@@ -5,7 +5,7 @@ from django.test import TestCase
 
 from pgq.decorators import task, JobMeta
 from pgq.models import Job
-from pgq.queue import AtLeastOnceQueue, AtMostOnceQueue, Queue
+from pgq.queue import AtLeastOnceQueue, Queue
 
 
 class PgqDecoratorsTests(TestCase):

--- a/testproj/tests.py
+++ b/testproj/tests.py
@@ -91,7 +91,11 @@ class PgqQueueTests(TestCase):
             task_name,
             [
                 {"args": {"count": 5}},
-                {"args": {"count": 7}, "priority": 10, "execute_at": day_from_now,},
+                {
+                    "args": {"count": 7},
+                    "priority": 10,
+                    "execute_at": day_from_now,
+                },
             ],
         )
         jobs = Job.objects.all()
@@ -152,7 +156,11 @@ class PgqQueueTests(TestCase):
         self.assertEqual(AltJob.objects.count(), 0)
 
         jobs = queue.bulk_enqueue(
-            "demotask", [{"args": {"count": 5}}, {"args": {"count": 7}},],
+            "demotask",
+            [
+                {"args": {"count": 5}},
+                {"args": {"count": 7}},
+            ],
         )
 
         self.assertEqual(AltJob.objects.count(), 2)
@@ -245,7 +253,11 @@ class PgqTransactionTests(TransactionTestCase):
             "demotask",
             [
                 {"args": {"count": 5}},
-                {"args": {"count": 7}, "priority": 10, "execute_at": now,},
+                {
+                    "args": {"count": 7},
+                    "priority": 10,
+                    "execute_at": now,
+                },
             ],
         )
 
@@ -306,6 +318,7 @@ class PgqTransactionTests(TransactionTestCase):
         being committed before the exception is raised (so the job has
         already been popped from the db as successful).
         """
+
         def failuretask(queue: Queue, job: Job):
             transaction.on_commit(lambda: 1 / 0)
             return None
@@ -335,7 +348,9 @@ class PgqTransactionTests(TransactionTestCase):
             transaction.on_commit(lambda: 1 / 0)
             return None
 
-        test_queue = AtLeastOnceQueue(tasks={"failuretask": failuretask}, queue=queue_name)
+        test_queue = AtLeastOnceQueue(
+            tasks={"failuretask": failuretask}, queue=queue_name
+        )
 
         test_queue.enqueue("failuretask")
         self.assertEqual(Job.objects.count(), 1)

--- a/testproj/urls.py
+++ b/testproj/urls.py
@@ -13,9 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url
+
+from django.urls import path
 from django.contrib import admin
 
 urlpatterns = [
-    url(r"^admin/", admin.site.urls),
+    path("admin/", admin.site.urls),
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,12 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django22,
-    py{36,37,38,39}-django31,
-    py{36,37,38,39}-django32,
+    py{310,311,312,313}-django42,
+    py{310,311,312,313}-django52,
 
 [testenv]
 passenv = GITHUB_WORKFLOW
 commands = python manage.py test
 deps =
     psycopg2-binary
-    dataclasses; python_version<"3.7"
-    django22: django~=2.2.17  # first patch release with Python 3.9 support
-    django22: psycopg2-binary<2.9
-    django31: django~=3.1.3  # first patch release with Python 3.9 support
-    django32: django~=3.2.0
+    django42: django~=4.2.0
+    django52: django~=5.2.0


### PR DESCRIPTION
- Update Python versions from 3.6-3.9 to 3.10-3.13 (aligned with current support)
- Update Django test matrix to 4.2 LTS and 5.2 LTS (dropping EOL versions)
- Remove tox-factor dependency (incompatible with modern tox)
- Fix Django URLs configuration for modern Django compatibility
- Update GitHub Actions to use newer action versions (v4)
- Fix manage.py to use modern importlib.util.find_spec()
- Add pre-commit configuration with ruff and standard hooks

This ensures compatibility with currently supported Python, Django, and PostgreSQL versions while maintaining clean code standards.

Based on research:
- Python 3.9 ends support October 2025 (only 2 months left)
- Django 4.2 LTS supported until April 2026
- Django 5.2 LTS supported until April 2028
- PostgreSQL 13+ supported through 2025+
